### PR TITLE
🐛  Fix Development Container 

### DIFF
--- a/contrib/Dockerfile.ollama
+++ b/contrib/Dockerfile.ollama
@@ -1,0 +1,15 @@
+FROM docker.io/ollama/ollama:latest
+
+RUN <<EOF
+# Start Ollama
+nohup ollama serve &
+
+# Wait for Ollama to start
+sleep 15
+
+# Pull model
+ollama pull llama3
+
+# Kill Ollama process
+kill -9 $(ps aux | grep "ollama" | grep -v "grep" | awk '{print $2}')
+EOF

--- a/contrib/docker-compose-ollama.yml
+++ b/contrib/docker-compose-ollama.yml
@@ -1,29 +1,8 @@
 ---
-version: '3.8'
-
 services:
   ollama:
-    image: ollama/ollama
+    # image: docker.io/ollama/ollama:latest
+    build:
+      dockerfile: ./Dockerfile.ollama
     ports:
       - 11434:11434
-    # command: >
-    #   echo "Starting Ollama server..."
-    #   ollama serve &
-    #   ollama run llama3
-
-
-    #   echo "Waiting for Ollama server to be active..."
-    #   while [ "$(ollama list | grep 'NAME')" == "" ]; do
-    #     sleep 1
-    #   done
-
-    # command: "ollama pull llama3"
-    # volumes:
-    #   - ./data:/app/data
-    # environment:
-    #   - ENV_VARIABLE=value
-    # healthcheck:
-    #   test: ["CMD", "curl", "-f", "http://localhost:11434/health"]
-    #   interval: 30s
-    #   timeout: 10s
-    #   retries: 3

--- a/scripts/devcontainer/post-create.sh
+++ b/scripts/devcontainer/post-create.sh
@@ -9,9 +9,6 @@ docker compose --file contrib/docker-compose-postgres.yml up --detach
 # Start Ollama Container
 docker compose --file contrib/docker-compose-ollama.yml up --detach
 
-# Start Ollama Model
-docker exec -it contrib-ollama-1 ollama run llama3 &
-
 # Upgrade Pip
 pip install --break-system-package --upgrade pip
 


### PR DESCRIPTION
This PR fixes the development container. Previously when built the devcontainer would not correctly pull and image and then proceed with the rest of the `post-create.sh` command. This PR introduces `Dockerfile.ollama` in an effort to isolate the functionality required to make this work as expected. The development container now pulls the latest `llama3` model. This can be edited/added to if necessary.

This PR resolves [this](https://github.com/orgs/ministryofjustice/projects/27?pane=issue&itemId=70651517) issue.