### PR TITLE
:wrench: Update workflow versions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Build Image
         id: build_image
-        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
+        uses: docker/build-push-action@1a162644f9a7e87d8f4b053101d1d9a712edc18c # v6.3.0
         with:
           push: false
           load: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,16 +26,16 @@ jobs:
 
       - name: Initialise CodeQL
         id: initialise_codeql
-        uses: github/codeql-action/init@407ffafae6a767df3e0230c3df91b6443ae8df75 # v2.22.8
+        uses: github/codeql-action/init@4fa2a7953630fd2f3fb380f21be14ede0169dd4f # v3.25.12
         with:
           languages: ${{ matrix.language }}
 
       - name: CodeQL Autobuild
         id: codeql_autobuild
-        uses: github/codeql-action/autobuild@407ffafae6a767df3e0230c3df91b6443ae8df75 # v2.22.8
+        uses: github/codeql-action/autobuild@4fa2a7953630fd2f3fb380f21be14ede0169dd4f # v3.25.12
 
       - name: CodeQL Analysis
         id: codeql_analysis
-        uses: github/codeql-action/analyze@407ffafae6a767df3e0230c3df91b6443ae8df75 # v2.22.8
+        uses: github/codeql-action/analyze@4fa2a7953630fd2f3fb380f21be14ede0169dd4f # v3.25.12
         with:
           category: "language:${{ matrix.language }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Build and Push
         id: build_and_push
-        uses: docker/build-push-action@15560696de535e4014efeff63c48f16952e52dd1 # v6.2.0
+        uses: docker/build-push-action@1a162644f9a7e87d8f4b053101d1d9a712edc18c # v6.3.0
         with:
           push: true
           tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}

--- a/.github/workflows/scan-image.yml
+++ b/.github/workflows/scan-image.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Build Image
         id: build_image
-        uses: docker/build-push-action@15560696de535e4014efeff63c48f16952e52dd1 # v6.2.0
+        uses: docker/build-push-action@1a162644f9a7e87d8f4b053101d1d9a712edc18c # v6.3.0
         with:
           push: false
           load: true
@@ -30,7 +30,7 @@ jobs:
 
       - name: Scan Image
         id: scan_image
-        uses: aquasecurity/trivy-action@7c2007bcb556501da015201bcba5aa14069b74e2 # v0.23.0
+        uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8 # v0.24.0
         with:
           image-ref: ollamate
           exit-code: 1
@@ -42,7 +42,7 @@ jobs:
       - name: Scan Image (On SARIF Scan Failure)
         if: failure() && steps.scan_image.outcome == 'failure'
         id: scan_image_on_failure
-        uses: aquasecurity/trivy-action@7c2007bcb556501da015201bcba5aa14069b74e2 # v0.23.0
+        uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8 # v0.24.0
         with:
           image-ref: ollamate
           exit-code: 1
@@ -52,6 +52,6 @@ jobs:
       - name: Upload SARIF
         if: always()
         id: upload_sarif
-        uses: github/codeql-action/upload-sarif@b611370bb5703a7efb587f9d136a52ea24c5c38c # v2.2.7
+        uses: github/codeql-action/upload-sarif@4fa2a7953630fd2f3fb380f21be14ede0169dd4f # v2.18.0
         with:
           sarif_file: trivy-results.sarif

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,8 +1,8 @@
 -r ./requirements.txt
-black==23.10.1
-django-stubs[compatible-mypy]==4.2.6
-flake8==6.1.0
+black==24.4.2
+django-stubs[compatible-mypy]==5.0.2
+flake8==7.1.0
 isort==5.12.0
-mypy==1.6.1
+mypy==1.10.1
 pre-commit==3.5.0
 types-requests==2.31.0


### PR DESCRIPTION
Resolves:

- [Bump aquasecurity/trivy-action from 0.23.0 to 0.24.0](https://github.com/ministryofjustice/analytical-platform-ollamate/pull/15)
- [Bump docker/build-push-action from 5.1.0 to 6.3.0](https://github.com/ministryofjustice/analytical-platform-ollamate/pull/13)
- [Bump django-stubs[compatible-mypy] from 4.2.6 to 5.0.2](https://github.com/ministryofjustice/analytical-platform-ollamate/pull/12)
- [Bump github/codeql-action from 2.22.8 to 3.25.12](https://github.com/ministryofjustice/analytical-platform-ollamate/pull/11)
- [Bump mypy from 1.6.1 to 1.10.1](https://github.com/ministryofjustice/analytical-platform-ollamate/pull/10)
- [Bump black from 23.10.1 to 24.4.2](https://github.com/ministryofjustice/analytical-platform-ollamate/pull/9)
- [Bump black from 23.10.1 to 24.3.0 in the pip group](https://github.com/ministryofjustice/analytical-platform-ollamate/pull/8)
- [Bump flake8 from 6.1.0 to 7.1.0](https://github.com/ministryofjustice/analytical-platform-ollamate/pull/7)